### PR TITLE
Fixup: fix typo for parameters.uri

### DIFF
--- a/src/commands/wait.yml
+++ b/src/commands/wait.yml
@@ -9,6 +9,6 @@ parameters:
     default: 30s
 steps:
   - run:
-      name: Wait << prameters.uri >>
+      name: Wait << parameters.uri >>
       command: |
         dockerize -wait "<< parameters.uri >>" -timeout "<< parameters.timeout >>"


### PR DESCRIPTION
This was causing CircleCI to complain when uri was not provided, but also complain when it was provided, saying that argument was unknown T_T.