### PR TITLE
ci: Specify orb-tools orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@volatile
+  orb-tools: circleci/orb-tools@2.0.2
   cli: circleci/circleci-cli@volatile
 
 workflows:


### PR DESCRIPTION
- `publish-token-variable` parameter interface has been changed by https://github.com/CircleCI-Public/orb-tools-orb/pull/13